### PR TITLE
Make click event handlers run asynchronously to prevent blocking UI

### DIFF
--- a/libs/js/clickheat-original.js
+++ b/libs/js/clickheat-original.js
@@ -28,11 +28,11 @@ function addEvtListener(obj, evtName, f)
 	{
 		if (obj)
 		{
-			obj.addEventListener(evtName, f, false);
+			obj.addEventListener(evtName, function() {setTimeout(f, 20)}, false);
 		}
 		else
 		{
-			addEventListener(evtName, f, false);
+			addEventListener(evtName, function() {setTimeout(f, 20)}, false);
 		}
 	}
 	/* IE */
@@ -40,11 +40,11 @@ function addEvtListener(obj, evtName, f)
 	{
 		if (obj)
 		{
-			obj.attachEvent('on' + evtName, f);
+			obj.attachEvent('on' + evtName, function() {setTimeout(f, 20)});
 		}
 		else
 		{
-			attachEvent('on' + evtName, f);
+			attachEvent('on' + evtName, function() {setTimeout(f, 20)});
 		}
 	}
 }


### PR DESCRIPTION
Currently when clicking, if the site has any animations they freeze for a second until the AJAX request goes through.
This makes the click events fire after a very short timeout (~1-3 frames), so that it doesn't block UI animations on the initial click.

The JS file will have to be recompiled in a seperate commit, as I don't know what minimizer you used.
